### PR TITLE
Make ViewStates Conform to Equatable

### DIFF
--- a/ReduxMovieDB/ViewState/MovieDetailViewState.swift
+++ b/ReduxMovieDB/ViewState/MovieDetailViewState.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MovieDetailViewState {
+struct MovieDetailViewState: Equatable {
     let movie: Movie?
 
     let title: String

--- a/ReduxMovieDB/ViewState/MovieListViewState.swift
+++ b/ReduxMovieDB/ViewState/MovieListViewState.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Matheus Cardoso. All rights reserved.
 //
 
-struct MovieListViewState {
+struct MovieListViewState: Equatable {
     let movies: [Movie]
     let searchBarText: String
     let searchBarShowsCancel: Bool
@@ -28,7 +28,6 @@ struct MovieListViewState {
             searchBarText = text
             searchBarShowsCancel = true
             searchBarFirstResponder = true
-
         }
     }
 }

--- a/ReduxMovieDB/ViewState/MovieListViewState.swift
+++ b/ReduxMovieDB/ViewState/MovieListViewState.swift
@@ -28,6 +28,7 @@ struct MovieListViewState: Equatable {
             searchBarText = text
             searchBarShowsCancel = true
             searchBarFirstResponder = true
+
         }
     }
 }


### PR DESCRIPTION
This resolves issue #4. 

since [ReSwift 4.0.1](https://github.com/ReSwift/ReSwift/releases/tag/4.0.1) `skipRepeats` is on by default when the SubStates are Equatable. After doing this, I tested it and `newState` for MovieListVC and MovieDetailVC is called a few times less. 