### PR TITLE
Fix excessive TMDB requests sent when viewing movie details

### DIFF
--- a/ReduxMovieDB/Actions/MainStateAction.swift
+++ b/ReduxMovieDB/Actions/MainStateAction.swift
@@ -20,4 +20,7 @@ enum MainStateAction: Action {
     case readySearch
     case search(String)
     case cancelSearch
+    
+    case collapseSplitDetail
+    case separateSplitDetail
 }

--- a/ReduxMovieDB/Controllers/MovieListViewController.swift
+++ b/ReduxMovieDB/Controllers/MovieListViewController.swift
@@ -39,7 +39,7 @@ class MovieListViewController: UIViewController {
     @IBOutlet weak var searchBar: UISearchBar! {
         didSet {
             searchBar.rx.textDidBeginEditing
-                .filter { self.searchBar.text?.isEmpty ?? false }
+                .filter { (self.searchBar.text?.isEmpty ?? false) && mainStore.state.canDispatchSearchActions }
                 .bind(onNext: {
                     mainStore.dispatch(MainStateAction.readySearch)
                     mainStore.dispatch(fetchMoviesPage)
@@ -47,7 +47,7 @@ class MovieListViewController: UIViewController {
                 .disposed(by: disposeBag)
 
             searchBar.rx.text.orEmpty
-                .filter { !$0.isEmpty }
+                .filter { !$0.isEmpty && mainStore.state.canDispatchSearchActions }
                 .bind(onNext: {
                     mainStore.dispatch(MainStateAction.search($0))
                     mainStore.dispatch(fetchMoviesPage)
@@ -55,7 +55,7 @@ class MovieListViewController: UIViewController {
                 .disposed(by: disposeBag)
 
             searchBar.rx.text.orEmpty
-                .filter { $0.isEmpty }
+                .filter { $0.isEmpty && mainStore.state.canDispatchSearchActions }
                 .bind(onNext: { _ in
                     mainStore.dispatch(MainStateAction.readySearch)
                     mainStore.dispatch(fetchMoviesPage)

--- a/ReduxMovieDB/Controllers/SplitViewController.swift
+++ b/ReduxMovieDB/Controllers/SplitViewController.swift
@@ -54,6 +54,12 @@ extension SplitViewController: StoreSubscriber {
 
 extension SplitViewController: UISplitViewControllerDelegate {
     func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
+        mainStore.dispatch(MainStateAction.collapseSplitDetail)
         return true
+    }
+    
+    func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
+        mainStore.dispatch(MainStateAction.separateSplitDetail)
+        return nil
     }
 }

--- a/ReduxMovieDB/State/MainState.swift
+++ b/ReduxMovieDB/State/MainState.swift
@@ -32,16 +32,32 @@ enum MovieDetailState: Equatable {
     }
 }
 
+enum SplitDetailState: Equatable {
+    case collapsed
+    case separated
+}
+
 struct MainState: StateType, Equatable {
     var genres: [Genre] = []
     var moviePages: Pages<Movie> = Pages<Movie>()
 
     var movieDetail: MovieDetailState = .hide
+    var splitDetail: SplitDetailState = .separated
 
     var search: SearchState = .canceled
 
     var movies: [Movie] {
         return moviePages.values
+    }
+    
+    var canDispatchSearchActions: Bool {
+        switch (splitDetail, movieDetail) {
+        case (.separated, _),
+             (.collapsed, .hide):
+            return true
+        default:
+            return false
+        }
     }
 }
 
@@ -78,6 +94,10 @@ func mainReducer(action: Action, state: MainState?) -> MainState {
     case .search(let query):
         state.moviePages = Pages<Movie>()
         state.search = .searching(query)
+    case .collapseSplitDetail:
+        state.splitDetail = .collapsed
+    case .separateSplitDetail:
+        state.splitDetail = .separated
     }
 
     return state

--- a/ReduxMovieDBTests/State/MainStateTests.swift
+++ b/ReduxMovieDBTests/State/MainStateTests.swift
@@ -25,6 +25,8 @@ class ReduxMovieDBTests: XCTestCase {
         case .readySearch: return testReadySearch
         case .search(_): return testSearch
         case .cancelSearch: return testCancelSearch
+        case .collapseSplitDetail: return testCollapseSplitDetail
+        case .separateSplitDetail: return testSeparateSplitDetail
         }
     }
 
@@ -154,4 +156,57 @@ class ReduxMovieDBTests: XCTestCase {
         }
     }
     
+    func testCollapseSplitDetail() {
+        let action = MainStateAction.collapseSplitDetail
+        
+        let state = mainReducer(action: action, state: nil)
+
+        guard case .collapsed = state.splitDetail else {
+            return XCTFail()
+        }
+    }
+    
+    func testSeparateSplitDetail() {
+       let action = MainStateAction.separateSplitDetail
+       
+       let state = mainReducer(action: action, state: nil)
+
+       guard case .separated = state.splitDetail else {
+           return XCTFail()
+       }
+    }
+    
+    func testSearchEventsDispatchOnSplitCollapse() {
+        let action1 = MainStateAction.collapseSplitDetail
+        let state1 = mainReducer(action: action1, state: nil)
+        
+        let action2 = MainStateAction.showMovieDetail(
+            Movie(id: 0, title: "title", releaseDate: "date", posterPath: "path", genreIds: [], overview: "")
+        )
+        let state2 = mainReducer(action: action2, state: state1)
+        
+        let action3 = MainStateAction.hideMovieDetail
+        let state3 = mainReducer(action: action3, state: state2)
+        
+        XCTAssert(state1.canDispatchSearchActions == true)
+        XCTAssert(state2.canDispatchSearchActions == false)
+        XCTAssert(state3.canDispatchSearchActions == true)
+    }
+    
+    func testSearchEventsDispatchOnSplitSeparate() {
+        let action1 = MainStateAction.separateSplitDetail
+        let state1 = mainReducer(action: action1, state: nil)
+        
+        let action2 = MainStateAction.showMovieDetail(
+            Movie(id: 0, title: "title", releaseDate: "date", posterPath: "path", genreIds: [], overview: "")
+        )
+        let state2 = mainReducer(action: action2, state: state1)
+        
+        let action3 = MainStateAction.hideMovieDetail
+        let state3 = mainReducer(action: action3, state: state2)
+        
+        XCTAssert(state1.canDispatchSearchActions == true)
+        XCTAssert(state2.canDispatchSearchActions == true)
+        XCTAssert(state3.canDispatchSearchActions == true)
+    }
 }


### PR DESCRIPTION
**Issue:**
The movies list gets re-fetched each time the user opens or exits the movie details screen on a device with a `compact-width` trait (e.g. iPhoneX or iPhone XS Max in portrait orientation). See the attached gif with a dump of requests being sent when I was opening various movie details

Why this happens:
- the `searchBar.rx.text` event stream triggers the movie search state updates and TMDB requests
- the events for the `text` control property are triggered by both text editing events and responder events (e.g. begin/end editing)
- when the user opens the movie details screen, the search bar resigns the responder thus triggering the main state update and dispatching a new TMDB request

**Proposed solution**:
This pull request adds a couple of new actions to differentiate when the movie details screen is always visible in a split view controller. If the details screen is currently the only visible one, e.g. in a compact-width device orientation, the `searchBar.rx.text` events are additionally filtered to disallow updating the search state when the search screen is not visible

![Screen Recording 2019-10-07 at 3 19 13 PM](https://user-images.githubusercontent.com/1830010/66311226-a9de9600-e916-11e9-8f04-ce5c26c6cc9f.gif)