### PR TITLE
Remove disclosureIndicator in MovieListTableViewCell

### DIFF
--- a/ReduxMovieDB/Controllers/MovieListViewController.swift
+++ b/ReduxMovieDB/Controllers/MovieListViewController.swift
@@ -123,8 +123,6 @@ class MovieListTableViewCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        accessoryType = selected ? .none : .disclosureIndicator
     }
 
     var movie: Movie? {
@@ -153,7 +151,6 @@ extension MovieListViewController: UITableViewDataSource {
         }
 
         cell.movie = movies[indexPath.row]
-        cell.accessoryType = .disclosureIndicator
         cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
         cell.selectionStyle = .none
 


### PR DESCRIPTION
To resolve this bug, was necessary to remove the disclosure indicator of accessory view in MovieListTableViewCell.